### PR TITLE
Calling different methods for skip and finish button

### DIFF
--- a/src/components/VStep.vue
+++ b/src/components/VStep.vue
@@ -15,10 +15,10 @@
 
     <slot name="actions">
       <div class="v-step__buttons">
-        <button @click.prevent="stop" v-if="!isLast" class="v-step__button">{{ labels.buttonSkip }}</button>
+        <button @click.prevent="skip" v-if="!isLast" class="v-step__button">{{ labels.buttonSkip }}</button>
         <button @click.prevent="previousStep" v-if="!isFirst" class="v-step__button">{{ labels.buttonPrevious }}</button>
         <button @click.prevent="nextStep" v-if="!isLast" class="v-step__button">{{ labels.buttonNext }}</button>
-        <button @click.prevent="stop" v-if="isLast" class="v-step__button">{{ labels.buttonStop }}</button>
+        <button @click.prevent="finish" v-if="isLast" class="v-step__button">{{ labels.buttonStop }}</button>
       </div>
     </slot>
 
@@ -46,6 +46,18 @@ export default {
     },
     stop: {
       type: Function
+    },
+    skip: {
+      type: Function,
+      default: function () {
+        this.stop()
+      }
+    },
+    finish: {
+      type: Function,
+      default: function () {
+        this.stop()
+      }
     },
     isFirst: {
       type: Boolean

--- a/src/components/VTour.vue
+++ b/src/components/VTour.vue
@@ -6,6 +6,8 @@
       :previous-step="previousStep"
       :next-step="nextStep"
       :stop="stop"
+      :skip="skip"
+      :finish="finish"
       :is-first="isFirst"
       :is-last="isLast"
       :labels="customOptions.labels"
@@ -20,6 +22,8 @@
         :previous-step="previousStep"
         :next-step="nextStep"
         :stop="stop"
+        :skip="skip"
+        :finish="finish"
         :is-first="isFirst"
         :is-last="isLast"
         :labels="customOptions.labels"
@@ -126,6 +130,14 @@ export default {
       this.customCallbacks.onStop()
       document.body.classList.remove(HIGHLIGHT.ACTIVE_TOUR)
       this.currentStep = -1
+    },
+    skip () {
+      this.customCallbacks.onSkip()
+      this.stop()
+    },
+    finish () {
+      this.customCallbacks.onFinish()
+      this.stop()
     },
 
     handleKeyup (e) {

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -2,7 +2,9 @@ export const DEFAULT_CALLBACKS = {
   onStart: () => {},
   onPreviousStep: (currentStep) => {},
   onNextStep: (currentStep) => {},
-  onStop: () => {}
+  onStop: () => {},
+  onSkip: () => {},
+  onFinish: () => {}
 }
 
 export const DEFAULT_OPTIONS = {

--- a/test/unit/VStep.spec.js
+++ b/test/unit/VStep.spec.js
@@ -1,6 +1,8 @@
 import { expect } from 'chai'
-import { shallow } from '@vue/test-utils'
+import { shallowMount } from '@vue/test-utils'
 import VStep from '@/components/VStep.vue'
+
+const labels = {}
 
 describe('VStep.vue', () => {
   it('renders props.step.content', () => {
@@ -9,13 +11,49 @@ describe('VStep.vue', () => {
       content: 'This is a demo step!'
     }
 
-    const wrapper = shallow(VStep, {
+    const wrapper = shallowMount(VStep, {
       propsData: {
         step,
-        stop: () => {}
+        stop: () => {},
+        labels
       }
     })
 
     expect(wrapper.text()).to.include(step.content)
+  })
+
+  it('calls skip and finish without value', () => {
+    const step = {
+      target: 'v-step-0',
+      content: 'This is a demo step!'
+    }
+
+    let i = 0
+    const mockstop = () => {
+      i++
+    }
+
+    // We don't provide skip and finish function
+    const wrapper = shallowMount(VStep, {
+      propsData: {
+        step,
+        stop: mockstop,
+        labels
+      }
+    })
+
+    expect(i).to.equal(0)
+
+    // When call stop, the value of i changes
+    wrapper.vm.stop()
+    expect(i).to.equal(1)
+
+    // When call skip, the stop function is called
+    wrapper.vm.skip()
+    expect(i).to.equal(2)
+
+    // When call finish, the stop function is called
+    wrapper.vm.finish()
+    expect(i).to.equal(3)
   })
 })


### PR DESCRIPTION
Relating to #64 , have the possibility to call different methods between the skip and finish button.
It still works with the stop function (Unit test).
The user can define a custom onSkip and onFinish function.