### PR TITLE
Add example step title and link to placement options

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ The `target` property of each step can target a DOM element in any component of 
         steps: [
           {
             target: '#v-step-0',  // We're using document.querySelector() under the hood
+            header: {
+              title: 'Get Started',
+            },
             content: `Discover <strong>Vue Tour</strong>!`
           },
           {
@@ -69,7 +72,7 @@ The `target` property of each step can target a DOM element in any component of 
             target: '[data-v-step="2"]',
             content: 'Try it, you\'ll love it!<br>You can put HTML in the steps and completely customize the DOM to suit your needs.',
             params: {
-              placement: 'top'
+              placement: 'top' // Any valid Popper.js placement. See https://popper.js.org/popper-documentation.html#Popper.placements
             }
           }
         ]


### PR DESCRIPTION
I only found the 'header' option bu reading the source code so I thought it's worth adding to the example docs.

I've also added a link to the popper js docs for placement options