### PR TITLE
feat: add enabledButtons new props (all true by default) which can

### DIFF
--- a/src/components/VStep.vue
+++ b/src/components/VStep.vue
@@ -15,10 +15,10 @@
 
     <slot name="actions">
       <div class="v-step__buttons">
-        <button @click.prevent="stop" v-if="!isLast" class="v-step__button">{{ labels.buttonSkip }}</button>
-        <button @click.prevent="previousStep" v-if="!isFirst" class="v-step__button">{{ labels.buttonPrevious }}</button>
-        <button @click.prevent="nextStep" v-if="!isLast" class="v-step__button">{{ labels.buttonNext }}</button>
-        <button @click.prevent="stop" v-if="isLast" class="v-step__button">{{ labels.buttonStop }}</button>
+        <button @click.prevent="stop" v-if="!isLast && checkEnabledButtons('buttonSkip')" class="v-step__button">{{ labels.buttonSkip }}</button>
+        <button @click.prevent="previousStep" v-if="!isFirst && checkEnabledButtons('buttonPrevious')" class="v-step__button">{{ labels.buttonPrevious }}</button>
+        <button @click.prevent="nextStep" v-if="!isLast && checkEnabledButtons('buttonNext')" class="v-step__button">{{ labels.buttonNext }}</button>
+        <button @click.prevent="stop" v-if="isLast && checkEnabledButtons('buttonStop')" class="v-step__button">{{ labels.buttonStop }}</button>
       </div>
     </slot>
 
@@ -54,6 +54,9 @@ export default {
       type: Boolean
     },
     labels: {
+      type: Object
+    },
+    enabledButtons: {
       type: Object
     }
   },
@@ -104,6 +107,9 @@ export default {
         console.error('[Vue Tour] The target element ' + this.step.target + ' of .v-step[id="' + this.hash + '"] does not exist!')
         this.$emit('targetNotFound', this.step)
       }
+    },
+    checkEnabledButtons (name) {
+      return this.enabledButtons.hasOwnProperty(name) ? this.enabledButtons[name] : true
     }
   },
   mounted () {

--- a/src/components/VTour.vue
+++ b/src/components/VTour.vue
@@ -9,6 +9,7 @@
       :is-first="isFirst"
       :is-last="isLast"
       :labels="customOptions.labels"
+      :enabled-buttons="customOptions.enabledButtons"
     >
       <!--Default slot {{ currentStep }}-->
       <v-step
@@ -22,6 +23,7 @@
         :is-first="isFirst"
         :is-last="isLast"
         :labels="customOptions.labels"
+        :enabled-buttons="customOptions.enabledButtons"
       >
         <!--<div v-if="index === 2" slot="actions">
           <a @click="nextStep">Next step</a>

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -13,6 +13,12 @@ export const DEFAULT_OPTIONS = {
     buttonPrevious: 'Previous',
     buttonNext: 'Next',
     buttonStop: 'Finish'
+  },
+  enabledButtons: {
+    buttonSkip: true,
+    buttonPrevious: true,
+    buttonNext: true,
+    buttonStop: true
   }
 }
 


### PR DESCRIPTION
enable or disable the buttons of vue tour. This references #93.

Not sure if this is good enough. Right now I'm using `v-if` to all the buttons, so the buttons instead of being disabled, will not be rendered (looks better in my opinion).

I used a method which checks for `hasOwnProperty`, otherwise returns true, so the user can just set one property and all the rest remains enabled, just like:

```javascript
options: {
  enabledButtons: {
    buttonSkip: false
  }
}
```

Any changes just let me know. Thank you.