### PR TITLE
feat: enable specific navigation keys

### DIFF
--- a/src/components/VTour.vue
+++ b/src/components/VTour.vue
@@ -151,15 +151,19 @@ export default {
       }
       switch (e.keyCode) {
         case KEYS.ARROW_RIGHT:
-          this.nextStep()
+          this.isKeyEnabled('ARROW_RIGHT') && this.nextStep()
           break
         case KEYS.ARROW_LEFT:
-          this.previousStep()
+          this.isKeyEnabled('ARROW_LEFT') && this.previousStep()
           break
         case KEYS.ESCAPE:
-          this.stop()
+          this.isKeyEnabled('ESCAPE') && this.stop()
           break
       }
+    },
+    isKeyEnabled (key) {
+      const { enabledNavigationKeys } = this.customOptions
+      return enabledNavigationKeys.hasOwnProperty(key) ? enabledNavigationKeys[key] : true
     }
   }
 }

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -23,6 +23,11 @@ export const DEFAULT_OPTIONS = {
   },
   startTimeout: 0,
   useKeyboardNavigation: true,
+  enabledNavigationKeys: {
+    ESCAPE: true,
+    ARROW_RIGHT: true,
+    ARROW_LEFT: true
+  },
   debug: false
 }
 


### PR DESCRIPTION
fixes #128 
Allows users to disable specific navigation keys via the options prop. If a key is not set, assumed to be enabled.

For example, to disable the escape key only, you could bind the following options object to the `VTour` `options` prop.
```javascript
const options =  {
    enabledNavigationKeys: {
        ESCAPE: false,
    },
}
```
exposes `ARROW_LEFT` and `ARROW_RIGHT` nav keys as well. 