### PR TITLE
Update VStep.vue

### DIFF
--- a/src/components/VStep.vue
+++ b/src/components/VStep.vue
@@ -145,7 +145,7 @@ export default {
           jump(this.targetElement, jumpOptions)
         } else {
           // Use the native scroll by default if no scroll options has been defined
-          this.targetElement.scrollIntoView({ behavior: 'smooth' })
+          this.targetElement.scrollIntoView({ behavior: 'smooth', block: 'center' })
         }
       }
     },


### PR DESCRIPTION
Without 'block: "center' in the scrollIntoView method it will default to scrolling the page until the element is at the very top of the page, for most users they will want the tour step to be in the center of the page instead, adding this will account for that.