### PR TITLE
use getComputedStyle instead of inline style

### DIFF
--- a/src/components/VStep.vue
+++ b/src/components/VStep.vue
@@ -167,7 +167,7 @@ export default {
 
         this.targetElement.classList.add(HIGHLIGHT.classes.targetHighlighted)
         // The element must have a position, if it doesn't have one, add a relative position class
-        if (!this.targetElement.style.position) {
+        if (!window.getComputedStyle(this.targetElement).getPropertyValue('position')) {
           this.targetElement.classList.add(HIGHLIGHT.classes.targetRelative)
         }
       } else {


### PR DESCRIPTION
`this.targetElement.style` is only for _inline_ styles - which means VStep components would erroneously add a class (if you used highlighting) which overrides any position values regardless of whether they exist in the element's class or not. This fix will use the computed style instead.